### PR TITLE
add new admin-cms-graphql-rc 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CMS Graphql RC 1.x.
 
 ## [1.0.0] - 2021-10-28
 

--- a/node/middlewares/schema.ts
+++ b/node/middlewares/schema.ts
@@ -48,6 +48,22 @@ const apps = [
       new NamespaceUnderFieldTransform(typeName, fieldName),
     ],
   },
+  {
+    app: 'vtex.admin-cms-graphql-rc@1.x',
+    executor: (app: string) =>
+      getExecutorForApp(app, ({ vtex: { authToken } }: Context) => ({
+        headers: {
+          // Add this App's authToken so we have permission to read from Dynamic Storage without the need of the user passing a token
+          // This should be safe since we are only exposing the `pages` query, that should not export any sensitive data
+          cookie: `VtexIdclientAutCookie=${authToken}`,
+        },
+      })),
+    transforms: [
+      new FilterRootFields(operation => operation === 'Query'),
+      new RenameTypes(name => `${typeName}_${name}`),
+      new NamespaceUnderFieldTransform(typeName, fieldName),
+    ],
+  },
 ]
 
 export default async function schema(ctx: Context, next: () => Promise<void>) {

--- a/node/package.json
+++ b/node/package.json
@@ -15,7 +15,7 @@
     "isomorphic-unfetch": "^3.1.0"
   },
   "devDependencies": {
-    "@vtex/api": "6.45.4",
+    "@vtex/api": "6.45.12",
     "typescript": "3.9.7",
     "vtex.admin-cms-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin-cms-graphql@0.15.0/public/@types/vtex.admin-cms-graphql",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -411,10 +411,10 @@
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-"@vtex/api@6.45.4":
-  version "6.45.4"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.4.tgz#58be7497c0c0f91a388fabd42149e48cb95e271d"
-  integrity sha512-DVAJr5BkSjXupjn2h5Z1In8C3Li9kZwCXPwRQbpIgyS7s9dN2ZEFQc6nQlJm6ZoDCoyYBg62LgD7Kurvz9jc3w==
+"@vtex/api@6.45.12":
+  version "6.45.12"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
+  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
### What problem is this solving?

We need to add the new Admin CMS Graphql RC 1.x to the list of apps that fetch schema automatically for faststore.
Current stores still using this solution: avongroup (ws faststore), carrefourbrfood (ws jamstackprod), marinbrasil (master).

Our current fix for this problem has been installing `v install vtex.graphql-gateway@1.0.1-hkignore.0` that changes the `0.x` to `1.x`, but I've tested the app with both, and it worked.

### How should this be manually tested?

[public graphql for Marin Brasil](https://newcms--marinbrasil.myvtex.com/graphql)

use this query:
```graphql
{
  vtex {
    contents(first:10) {
      edges {
        node {
          id
        }
      }
    }
  }
}
```

Another approach is installing this version and doing a `yarn build` inside any store that uses this graphql-gateway.

### Error 🚨

It breaks when the app 1.x is not installed. It would be solved using Promise.allSettled for fetching schemas or changing the Promise to not fail on errors.

### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
