### PR TITLE
Remove admin-cms-graphql dependency and restrict cms-graphql-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- `admin-cms-graphql@0.x` and `admin-cms-graphql-rc@1.x`.
 
 ## [1.0.0] - 2021-10-28
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,7 @@
   },
   "dependencies": {
     "vtex.search-resolver": "1.x",
-    "vtex.checkout-graphql": "0.x",
-    "vtex.admin-cms-graphql": "0.x"
+    "vtex.checkout-graphql": "0.x"
   },
   "credentialType": "absolute",
   "policies": [
@@ -20,9 +19,6 @@
     },
     {
       "name": "vbase-read-write"
-    },
-    {
-      "name": "vtex.admin-cms-graphql:graphql-api"
     },
     {
       "name": "graphql-query"

--- a/node/middlewares/schema.ts
+++ b/node/middlewares/schema.ts
@@ -38,12 +38,14 @@ const apps = [
       getExecutorForApp(app, ({ vtex: { authToken } }: Context) => ({
         headers: {
           // Add this App's authToken so we have permission to read from Dynamic Storage without the need of the user passing a token
-          // This should be safe since we are only exposing the `pages` query, that should not export any sensitive data
+          // This should be safe since we are only exposing the `contents` query, that should not export any sensitive data
           cookie: `VtexIdclientAutCookie=${authToken}`,
         },
       })),
     transforms: [
-      new FilterRootFields(operation => operation === 'Query'),
+      new FilterRootFields(
+        (operation, rootField) => operation === 'Query' && rootField === 'contents'
+      ),
       new RenameTypes(name => `${typeName}_${name}`),
       new NamespaceUnderFieldTransform(typeName, fieldName),
     ],

--- a/node/middlewares/schema.ts
+++ b/node/middlewares/schema.ts
@@ -1,6 +1,5 @@
 import { mergeSchemas } from '@graphql-tools/merge'
 import {
-  FilterRootFields,
   introspectSchema,
   RenameTypes,
   wrapSchema,
@@ -31,25 +30,7 @@ const apps = [
       new RenameTypes(name => `${typeName}_${name}`),
       new NamespaceUnderFieldTransform(typeName, fieldName),
     ],
-  },
-  {
-    app: 'vtex.admin-cms-graphql-rc@0.x',
-    executor: (app: string) =>
-      getExecutorForApp(app, ({ vtex: { authToken } }: Context) => ({
-        headers: {
-          // Add this App's authToken so we have permission to read from Dynamic Storage without the need of the user passing a token
-          // This should be safe since we are only exposing the `contents` query, that should not export any sensitive data
-          cookie: `VtexIdclientAutCookie=${authToken}`,
-        },
-      })),
-    transforms: [
-      new FilterRootFields(
-        (operation, rootField) => operation === 'Query' && rootField === 'contents'
-      ),
-      new RenameTypes(name => `${typeName}_${name}`),
-      new NamespaceUnderFieldTransform(typeName, fieldName),
-    ],
-  },
+  }
 ]
 
 export default async function schema(ctx: Context, next: () => Promise<void>) {

--- a/node/package.json
+++ b/node/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@vtex/api": "6.45.4",
     "typescript": "3.9.7",
-    "vtex.admin-cms-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin-cms-graphql@0.15.0/public/@types/vtex.admin-cms-graphql",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",
     "vtex.graphql-gateway": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.graphql-gateway@0.7.0/public/_types/react",
     "vtex.search-resolver": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.29.4/public/_types/react"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2386,7 +2386,7 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz#c80757383c28abf7296744998cbc106ae8b854ce"
   integrity sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -2629,10 +2629,6 @@ vary@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
-
-"vtex.admin-cms-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin-cms-graphql@0.15.0/public/@types/vtex.admin-cms-graphql":
-  version "0.15.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin-cms-graphql@0.15.0/public/@types/vtex.admin-cms-graphql#0c418dbac747d7fcbabdbf0b71d42bcddb965747"
 
 "vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql":
   version "0.55.1"


### PR DESCRIPTION
#### What problem is this solving?

- Removed the dependency on [admin-cms-graphql](https://github.com/vtex/admin-cms-graphql) as it has been deprecated and unused for a long time.
- Removed the `admin-cms-graphql-rc` as it was not used for Graphql on the public gateway for Faststore (FS uses REST API).

Related to [VSC-10466](https://vtex-dev.atlassian.net/browse/VSC-10466).

#### How should this be manually tested?

workspace: [secgateway](https://secgateway--storecomponents.myvtex.com/admin/cms/site-editor)

#### Curl must works:
```bash
curl --location 'https://storetheme.vtex.com/_v/public/graphql/v1?workspace=secgateway' \
--header 'Content-Type: application/json' \
--header 'Cookie: janus_sid=2219b78f-92e8-4c79-910c-5d332f8f246f' \
--data '{"query":"query(\n  $first: Int\n  $last: Int\n  $before: String\n  $after: String\n  $orderBy: ContentsOrderInput\n  $filters: ContentsFiltersInput\n) {\n  contents(\n    first: $first\n    last: $last\n    before: $before\n    after: $after\n    orderBy: $orderBy\n    filters: $filters\n  ) {\n    pageInfo {\n        hasNextPage\n    }\n    edges {\n        node {\n            id\n            name\n            variants {\n                edges {\n                    node {\n                        id\n                        status\n                        \n                    }\n                }\n            }\n        }\n    }\n  }\n}","variables":{"first":15,"after":"index_0","filters":{"builderId":{"value":"cms"}},"orderBy":{"field":"UPDATED_AT","direction":"DESC"}}}'
```

```bash
curl --location 'https://storetheme.vtex.com/_v/public/graphql/v1?workspace=secgateway' \
--header 'Content-Type: application/json' \
--header 'Cookie: janus_sid=2219b78f-92e8-4c79-910c-5d332f8f246f' \
--data '{"query":"query(\n    $builderId: ID!\n) {\n  builder(builderId: $builderId) {\n    id\n    productionBaseUrl\n    sections {\n        name\n        # schema\n    }\n    contentTypes {\n        id\n        name\n    }\n    webhookUrl\n    checkBuildUrl\n    translationKeys\n  }\n}","variables":{"builderId":"faststore"}}'
```

#### You should not call the mutations due to https://github.com/vtex/admin-cms-graphql-rc/pull/323
```bash
curl --location 'https://storetheme.vtex.com/_v/private/graphql/v1?workspace=master' \
--header 'Content-Type: application/json' \
--header 'Cookie: janus_sid=2219b78f-92e8-4c79-910c-5d332f8f246f' \
--data-raw '{"query":"mutation createContent($input: CreateContentInput!) {\n  createContent(input: $input) @context(provider: \"vtex.admin-cms-graphql-rc\") {\n    content {\n        id\n        name\n        status\n        variants {\n            edges {\n                node {\n                    id\n                    sections {\n                        id\n                        data\n                    }\n                    configurationDataSets {\n                        name\n                        configurations {\n                            name\n                            data\n                        }\n                    }\n                    lastUpdatedAt\n                }\n            }\n        }\n    }\n  }\n}\n","variables":{"input":{"contentInput":{"contentName":"TEST Auth","builderId":"faststore","contentTypeId":"home"}}}}'
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).



[VSC-10466]: https://vtex-dev.atlassian.net/browse/VSC-10466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ